### PR TITLE
Fix player decoding

### DIFF
--- a/sfs.lua
+++ b/sfs.lua
@@ -905,14 +905,13 @@ do
         return Entity(ent_idx)
     end
 
-    local Player = Player
     decoders[PLAYER] = function(ctx)
         ctx[1] = ctx[1] + 1
         local ply_uid, err = read_u8(ctx)
         if err then
             return nil, err
         end
-        return Player(ply_uid)
+        return Entity(ply_uid)
     end
 
     local Vector = Vector


### PR DESCRIPTION
78016d6b9a22f0076b3a1f6aa99245a2a21d38c4 only updated the encoder part, the decoder still uses `Player()` which results in the following code not working as expected:

```lua
print(ply == sfs.decode(sfs.encode(ply), nil))
false
```